### PR TITLE
Send JSON-formatted DNS records to cache listener via UNIX socket

### DIFF
--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -1948,3 +1948,5 @@ int add_update_server(int flags,
 		      const char *interface,
 		      const char *domain,
 		      union all_addr *local_addr); 
+extern int cache_listener_sockfd;
+void init_cache_listener_socket(void);


### PR DESCRIPTION
- Send non-negative IPv4/IPv6 DNS records from cache_insert() as JSON over a persistent UNIX socket
- Messages include name, IP, and TTL
- Socket initialized once in dnsmasq.c